### PR TITLE
Align activity number badges with brand colors

### DIFF
--- a/index.html
+++ b/index.html
@@ -185,7 +185,7 @@
     <section id="activity-2" class="activity-card">
       <div class="flex items-start">
         <div class="mr-4 shrink-0">
-          <div class="h-10 w-10 rounded-xl grid place-items-center bg-green-100 text-green-700 font-bold">2</div>
+          <div class="h-10 w-10 rounded-xl grid place-items-center bg-brand-100 text-brand-700 font-bold">2</div>
         </div>
         <div>
           <h2 class="text-2xl font-extrabold mb-3">Unpacking the Real Deal 🎬</h2>
@@ -287,7 +287,7 @@
     <section id="activity-3" class="activity-card">
       <div class="flex items-start">
         <div class="mr-4 shrink-0">
-          <div class="h-10 w-10 rounded-xl grid place-items-center bg-purple-100 text-purple-700 font-bold">3</div>
+          <div class="h-10 w-10 rounded-xl grid place-items-center bg-brand-100 text-brand-700 font-bold">3</div>
         </div>
         <div>
           <h2 class="text-2xl font-extrabold mb-3">Vibe vs. Text Showdown ⚖️</h2>
@@ -351,7 +351,7 @@
     <section id="activity-4" class="activity-card">
       <div class="flex items-start">
         <div class="mr-4 shrink-0">
-          <div class="h-10 w-10 rounded-xl grid place-items-center bg-yellow-100 text-yellow-700 font-bold">4</div>
+          <div class="h-10 w-10 rounded-xl grid place-items-center bg-brand-100 text-brand-700 font-bold">4</div>
         </div>
         <div class="flex-1">
           <h2 class="text-2xl font-extrabold mb-3">Constitution Game 🎮</h2>


### PR DESCRIPTION
## Summary
- unify the activity badge backgrounds to use the brand blue palette so each step matches the site theme

## Testing
- not run (static HTML change)

------
https://chatgpt.com/codex/tasks/task_b_68d0844dac3c8327b6e096c98aa7ce40