### PR TITLE
Set game question text color to black

### DIFF
--- a/index.html
+++ b/index.html
@@ -361,7 +361,7 @@
           <h2 class="text-2xl font-extrabold mb-3">Constitution Game 🎮</h2>
           <p class="mb-4">Test your knowledge! Decide if each statement is part of the actual <strong>Text</strong> of the Constitution or just the <strong>Vibe</strong>.</p>
           <div id="game" class="max-w-xl mx-auto bg-white rounded-xl shadow p-6 border border-gray-200">
-            <div id="question" class="text-lg font-medium text-center mb-4"></div>
+            <div id="question" class="text-lg font-medium text-center mb-4 text-black dark:text-black"></div>
             <div class="flex justify-center gap-4 mb-4">
               <button onclick="answer('vibe')" class="px-4 py-2 rounded-lg bg-purple-600 text-white font-semibold hover:opacity-90">Vibe</button>
               <button onclick="answer('text')" class="px-4 py-2 rounded-lg bg-green-600 text-white font-semibold hover:opacity-90">Text</button>


### PR DESCRIPTION
## Summary
- set the game question element to use explicit black text so prompts display in black across themes

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68d08910d62c8327b9d042f535218312