### PR TITLE
Add lesson snapshot card to hero

### DIFF
--- a/index.html
+++ b/index.html
@@ -131,6 +131,24 @@
           <a href="#resources" class="inline-flex items-center rounded-xl border border-slate-300 dark:border-slate-700 px-5 py-3 font-semibold hover:bg-slate-50 dark:hover:bg-slate-800">Teacher Resources</a>
           <a href="#activity-4" class="inline-flex items-center rounded-xl bg-purple-600 px-5 py-3 text-white font-semibold shadow-soft hover:opacity-90">Play Game</a>
         </div>
+        <div class="mt-8 max-w-xl rounded-2xl border border-slate-200/80 bg-white/70 p-6 shadow-soft backdrop-blur dark:border-slate-800 dark:bg-slate-900/60">
+          <p class="text-sm font-semibold uppercase tracking-wide text-brand-700 dark:text-brand-200">Lesson Snapshot</p>
+          <dl class="mt-4 grid grid-cols-1 gap-4 text-sm sm:grid-cols-3">
+            <div>
+              <dt class="font-semibold text-slate-700 dark:text-slate-200">Year levels</dt>
+              <dd class="text-slate-600 dark:text-slate-300">Designed for Years 9–10, adaptable 7–12.</dd>
+            </div>
+            <div>
+              <dt class="font-semibold text-slate-700 dark:text-slate-200">Time needed</dt>
+              <dd class="text-slate-600 dark:text-slate-300">Approx. 2 × 50‑minute lessons.</dd>
+            </div>
+            <div>
+              <dt class="font-semibold text-slate-700 dark:text-slate-200">Focus</dt>
+              <dd class="text-slate-600 dark:text-slate-300">Comparing constitutional “vibes” with the actual text.</dd>
+            </div>
+          </dl>
+          <p class="mt-4 text-sm text-slate-600 dark:text-slate-300">Everything you need to spark discussion—videos, collaborative whiteboards, writing prompts, and a friendly quiz game.</p>
+        </div>
       </div>
       <div>
         <div class="relative">


### PR DESCRIPTION
## Summary
- add a lesson snapshot card to the hero to outline year levels, estimated timing, and lesson focus
- highlight the mix of resources included to quickly brief teachers on what’s inside the toolkit

## Testing
- not run (static content change)


------
https://chatgpt.com/codex/tasks/task_b_68d092e717fc8327adb6bbb3d86c6f67