### PR TITLE
Adjust writing panel font color

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,22 +39,22 @@
     #game{background:linear-gradient(135deg,rgba(255,255,255,.88),rgba(219,234,254,.7));border:1px solid rgba(191,219,254,.8);backdrop-filter:blur(8px);box-shadow:0 20px 40px rgba(15,23,42,.08)}
     .dark #game{background:rgba(15,23,42,.7);border-color:rgba(148,163,184,.45);box-shadow:none}
     .dark .activity-card{background-color:rgba(2,6,23,.7);border-color:#1f2937}
-    .writing-panel{display:flex;flex-direction:column;gap:.75rem;background:rgba(255,255,255,.92);border-radius:1rem;border:1px solid rgba(148,163,184,.4);padding:1.25rem;box-shadow:0 14px 30px rgba(15,23,42,.08)}
-    .dark .writing-panel{background:rgba(15,23,42,.72);border-color:rgba(148,163,184,.35);box-shadow:none}
+    .writing-panel{display:flex;flex-direction:column;gap:.75rem;background:rgba(255,255,255,.92);border-radius:1rem;border:1px solid rgba(148,163,184,.4);padding:1.25rem;box-shadow:0 14px 30px rgba(15,23,42,.08);color:#1e3a8a}
+    .dark .writing-panel{background:rgba(15,23,42,.72);border-color:rgba(148,163,184,.35);box-shadow:none;color:#e0e7ff}
     .writing-panel--accent{background:linear-gradient(135deg,rgba(196,181,253,.25),rgba(219,234,254,.24));border-color:rgba(168,85,247,.45)}
     .dark .writing-panel--accent{background:rgba(76,29,149,.45);border-color:rgba(168,85,247,.55)}
     .writing-panel--no-storage{border-color:rgba(249,115,22,.55)}
     .writing-panel__header{display:flex;flex-direction:column;gap:.5rem}
     .writing-panel__title{font-weight:700;font-size:1.05rem;letter-spacing:-.01em}
-    .writing-panel__prompt{font-size:.92rem;line-height:1.5;color:#475569}
-    .dark .writing-panel__prompt{color:rgba(226,232,240,.82)}
-    .writing-panel textarea{width:100%;min-height:150px;resize:vertical;border:1px solid rgba(148,163,184,.6);border-radius:.85rem;padding:.85rem 1rem;font:inherit;background-color:rgba(248,250,252,.94);transition:border-color .18s ease,box-shadow .18s ease,background-color .18s ease}
+    .writing-panel__prompt{font-size:.92rem;line-height:1.5;color:inherit}
+    .dark .writing-panel__prompt{color:inherit}
+    .writing-panel textarea{width:100%;min-height:150px;resize:vertical;border:1px solid rgba(148,163,184,.6);border-radius:.85rem;padding:.85rem 1rem;font:inherit;background-color:rgba(248,250,252,.94);transition:border-color .18s ease,box-shadow .18s ease,background-color .18s ease;color:inherit}
     .writing-panel textarea:focus{outline:none;border-color:#2563eb;box-shadow:0 0 0 3px rgba(37,99,235,.15);background-color:#fff}
     .writing-panel textarea::placeholder{color:rgba(100,116,139,.8)}
     .dark .writing-panel textarea{background-color:rgba(15,23,42,.65);border-color:rgba(148,163,184,.45);color:inherit}
     .dark .writing-panel textarea:focus{border-color:rgba(96,165,250,.8);box-shadow:0 0 0 3px rgba(96,165,250,.18);background-color:rgba(15,23,42,.85)}
-    .writing-panel__footer{display:flex;flex-wrap:wrap;align-items:center;justify-content:space-between;gap:.75rem;font-size:.875rem;color:#475569}
-    .dark .writing-panel__footer{color:rgba(226,232,240,.78)}
+    .writing-panel__footer{display:flex;flex-wrap:wrap;align-items:center;justify-content:space-between;gap:.75rem;font-size:.875rem;color:inherit}
+    .dark .writing-panel__footer{color:inherit}
     .writing-panel__status{display:flex;align-items:center;gap:.4rem;color:inherit}
     .writing-panel__status[data-state="success"]{color:#15803d}
     .writing-panel__status[data-state="info"]{color:#0369a1}


### PR DESCRIPTION
## Summary
- update writing panel text color to use a brand-aligned blue in light mode and a soft indigo in dark mode
- let prompts, footers, and textareas inherit the new color styling for consistent typography

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68d0941a708883278f47e5835e7f991a