### PR TITLE
Add Athens landmarks overlay and data

### DIFF
--- a/data/agora_local.json
+++ b/data/agora_local.json
@@ -1,0 +1,50 @@
+{
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "type": "Feature",
+      "geometry": { "type": "Point", "coordinates": [23.7223, 37.9758] },
+      "properties": {
+        "name": "Temple of Hephaistos",
+        "title": "Temple of Hephaistos",
+        "category": "cultural"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": { "type": "Point", "coordinates": [23.7239, 37.9750] },
+      "properties": {
+        "name": "Stoa of Attalos",
+        "title": "Stoa of Attalos",
+        "category": "cultural"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": { "type": "Point", "coordinates": [23.7213, 37.9748] },
+      "properties": {
+        "name": "Tholos",
+        "title": "Tholos",
+        "category": "democracy"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": { "type": "Point", "coordinates": [23.7214, 37.9751] },
+      "properties": {
+        "name": "Bouleuterion",
+        "title": "Bouleuterion",
+        "category": "democracy"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": { "type": "Point", "coordinates": [23.7232, 37.9757] },
+      "properties": {
+        "name": "Altar of the Twelve Gods",
+        "title": "Altar of the Twelve Gods",
+        "category": "cultural"
+      }
+    }
+  ]
+}

--- a/data/athens_places.geojson
+++ b/data/athens_places.geojson
@@ -1,0 +1,273 @@
+{
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "type": "Feature",
+      "geometry": { "type": "Point", "coordinates": [23.7266, 37.9715] },
+      "properties": {
+        "name": "Acropolis",
+        "title": "Acropolis of Athens",
+        "category": "cultural",
+        "pleiades_id": "588904"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": { "type": "Point", "coordinates": [23.7229, 37.9755] },
+      "properties": {
+        "name": "Agora",
+        "title": "Athenian Agora",
+        "category": "democracy",
+        "pleiades_id": "579885"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": { "type": "Point", "coordinates": [23.7189, 37.9728] },
+      "properties": {
+        "name": "Pnyx",
+        "title": "Pnyx Assembly Hill",
+        "category": "democracy",
+        "pleiades_id": "579903"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": { "type": "Point", "coordinates": [23.7244, 37.9734] },
+      "properties": {
+        "name": "Areopagus",
+        "title": "Areopagus Hill",
+        "category": "democracy",
+        "pleiades_id": "579885"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": { "type": "Point", "coordinates": [23.7196, 37.9794] },
+      "properties": {
+        "name": "Kerameikos",
+        "title": "Kerameikos",
+        "category": "cultural",
+        "pleiades_id": "579876"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": { "type": "Point", "coordinates": [23.7261, 37.9715] },
+      "properties": {
+        "name": "Parthenon",
+        "title": "Parthenon",
+        "category": "cultural",
+        "pleiades_id": "599561"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": { "type": "Point", "coordinates": [23.7269, 37.9721] },
+      "properties": {
+        "name": "Erechtheion",
+        "title": "Erechtheion",
+        "category": "cultural",
+        "pleiades_id": "599552"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": { "type": "Point", "coordinates": [23.7254, 37.9725] },
+      "properties": {
+        "name": "Propylaea",
+        "title": "Propylaea",
+        "category": "cultural",
+        "pleiades_id": "599576"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": { "type": "Point", "coordinates": [23.7253, 37.9723] },
+      "properties": {
+        "name": "Temple of Athena Nike",
+        "title": "Temple of Athena Nike",
+        "category": "cultural",
+        "pleiades_id": "599599"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": { "type": "Point", "coordinates": [23.7282, 37.9704] },
+      "properties": {
+        "name": "Theatre of Dionysus",
+        "title": "Theatre of Dionysus",
+        "category": "cultural",
+        "pleiades_id": "599622"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": { "type": "Point", "coordinates": [23.7241, 37.9700] },
+      "properties": {
+        "name": "Odeon of Herodes Atticus",
+        "title": "Odeon of Herodes Atticus",
+        "category": "cultural",
+        "pleiades_id": "599594"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": { "type": "Point", "coordinates": [23.7330, 37.9696] },
+      "properties": {
+        "name": "Temple of Olympian Zeus",
+        "title": "Temple of Olympian Zeus",
+        "category": "cultural",
+        "pleiades_id": "589872"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": { "type": "Point", "coordinates": [23.7246, 37.9749] },
+      "properties": {
+        "name": "Roman Agora",
+        "title": "Roman Agora",
+        "category": "cultural",
+        "pleiades_id": "717376"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": { "type": "Point", "coordinates": [23.7253, 37.9751] },
+      "properties": {
+        "name": "Tower of the Winds",
+        "title": "Tower of the Winds",
+        "category": "cultural",
+        "pleiades_id": "373951"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": { "type": "Point", "coordinates": [23.7249, 37.9750] },
+      "properties": {
+        "name": "Hadrian's Library",
+        "title": "Hadrian's Library",
+        "category": "cultural",
+        "pleiades_id": "373904"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": { "type": "Point", "coordinates": [23.7412, 37.9709] },
+      "properties": {
+        "name": "Panathenaic Stadium",
+        "title": "Panathenaic Stadium",
+        "category": "cultural",
+        "pleiades_id": "579939"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": { "type": "Point", "coordinates": [23.7240, 37.9738] },
+      "properties": {
+        "name": "Areopagus Viewpoint West",
+        "title": "Areopagus West Viewpoint",
+        "category": "natural"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": { "type": "Point", "coordinates": [23.7248, 37.9730] },
+      "properties": {
+        "name": "Areopagus Viewpoint South",
+        "title": "Areopagus South Viewpoint",
+        "category": "natural"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": { "type": "Point", "coordinates": [23.7252, 37.9743] },
+      "properties": {
+        "name": "Areopagus Viewpoint East",
+        "title": "Areopagus East Viewpoint",
+        "category": "natural"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [23.5420, 38.0410],
+          [23.5850, 38.0200],
+          [23.6300, 38.0000],
+          [23.6800, 37.9850],
+          [23.7205, 37.9786],
+          [23.7229, 37.9755],
+          [23.7254, 37.9725]
+        ]
+      },
+      "properties": {
+        "name": "Sacred Way (Eleusis–Athens)",
+        "title": "Sacred Way",
+        "category": "cultural"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [23.7205, 37.9786],
+          [23.7030, 37.9660],
+          [23.6900, 37.9550],
+          [23.6740, 37.9480],
+          [23.6460, 37.9420]
+        ]
+      },
+      "properties": {
+        "name": "Long Walls (Piraeus)",
+        "title": "Long Walls to Piraeus",
+        "category": "democracy"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [23.7205, 37.9786],
+          [23.7100, 37.9665],
+          [23.7020, 37.9590],
+          [23.6960, 37.9510],
+          [23.6900, 37.9450],
+          [23.7000, 37.9355]
+        ]
+      },
+      "properties": {
+        "name": "Long Walls (Phaleron)",
+        "title": "Long Walls to Phaleron",
+        "category": "democracy"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [23.7170, 37.9820],
+            [23.7320, 37.9820],
+            [23.7410, 37.9760],
+            [23.7410, 37.9670],
+            [23.7330, 37.9620],
+            [23.7210, 37.9630],
+            [23.7120, 37.9700],
+            [23.7070, 37.9770],
+            [23.7170, 37.9820]
+          ]
+        ]
+      },
+      "properties": {
+        "name": "City Wall of Athens",
+        "title": "Classical City Wall",
+        "category": "democracy"
+      }
+    }
+  ]
+}

--- a/index.html
+++ b/index.html
@@ -57,6 +57,26 @@
     .writing-panel__status[data-state="muted"]{color:#475569}
     .writing-panel__reset{border:1px solid rgba(148,163,184,.6);border-radius:9999px;padding:.35rem .85rem;font-size:.85rem;font-weight:600;color:#2563eb;background:#fff}
     .writing-panel__reset:hover{background:#dbeafe}
+
+    /* Athens map explorer */
+    #athens-map-wrapper{position:relative;border-radius:1.5rem;overflow:hidden;border:1px solid rgba(148,163,184,.35);background:linear-gradient(135deg,rgba(219,234,254,.35),rgba(248,250,252,.85));box-shadow:0 18px 36px rgba(15,23,42,.12)}
+    #athens-map{position:relative;height:420px}
+    #athens-3d-layer{position:absolute;inset:0;pointer-events:none}
+    #athens-agora-layer,#athens-pin-layer{position:absolute;inset:0}
+    #landmarks-canvas{position:absolute;inset:0;width:100%;height:100%;pointer-events:none}
+    .athens-pin{position:absolute;display:flex;flex-direction:column;align-items:center;gap:0.3rem;transform:translate(-50%,-100%);pointer-events:auto}
+    .athens-pin::before{content:'';width:14px;height:14px;border-radius:9999px;background:rgba(59,130,246,.95);box-shadow:0 0 0 2px rgba(255,255,255,.9);animation:pulse 2.4s infinite}
+    .athens-pin-label{padding:.2rem .45rem;border-radius:.5rem;background:rgba(15,23,42,.85);color:#f8fafc;font-size:.7rem;font-weight:600;letter-spacing:.01em;white-space:nowrap;box-shadow:0 8px 20px rgba(15,23,42,.28)}
+    @keyframes pulse{0%{transform:scale(1);opacity:.9}50%{transform:scale(1.25);opacity:.45}100%{transform:scale(1);opacity:.9}}
+    .mini-map{display:flex;flex-wrap:wrap;gap:.4rem;margin-top:1rem;padding:.75rem;border-radius:.85rem;background:rgba(15,23,42,.04);border:1px solid rgba(148,163,184,.35)}
+    .map-icon{width:10px;height:10px;border-radius:9999px;border:2px solid rgba(255,255,255,.85);box-shadow:0 2px 6px rgba(15,23,42,.25)}
+    .map-icon-democracy{background:#22c55e}
+    .map-icon-cultural{background:#ef4444}
+    .map-icon-natural{background:#2563eb}
+    .athens-mini-map-label{font-size:.75rem;color:#475569}
+    .athens-agora-building{position:absolute;width:32px;height:18px;border-radius:.35rem;border:1px solid rgba(59,130,246,.75);background:rgba(59,130,246,.3);transform:translate(-50%,-50%);box-shadow:0 4px 12px rgba(15,23,42,.25)}
+    .athens-agora-building[data-category="democracy"]{background:rgba(34,197,94,.35);border-color:rgba(22,163,74,.85)}
+    .athens-agora-building span{position:absolute;bottom:100%;left:50%;transform:translate(-50%,-.45rem);background:rgba(15,23,42,.85);color:#f8fafc;padding:.15rem .4rem;border-radius:.4rem;font-size:.65rem;font-weight:600;white-space:nowrap}
   </style>
 </head>
 <body class="bg-gray-50 text-slate-800 antialiased dark:bg-slate-950 dark:text-slate-100">
@@ -434,6 +454,30 @@
           </thead>
           <tbody id="dashRows"></tbody>
         </table>
+      </div>
+    </section>
+
+    <!-- Athens Map Explorer -->
+    <section id="athens-explorer" class="activity-card mt-12" aria-labelledby="athens-explorer-title">
+      <div class="flex items-center justify-between flex-wrap gap-3 mb-4">
+        <h2 id="athens-explorer-title" class="text-2xl font-extrabold">Athens Landmarks Explorer</h2>
+        <p class="text-sm text-slate-600 dark:text-slate-300 max-w-xl">
+          Explore key monuments of classical Athens. Pins mark major temples, civic buildings, and natural vantage points;
+          the mini-map highlights categories so students can compare democracy, cultural, and natural places at a glance.
+        </p>
+      </div>
+      <div id="athens-map-wrapper" class="mb-4">
+        <div id="athens-map">
+          <div id="athens-3d-layer" aria-hidden="true">
+            <div id="athens-agora-layer"></div>
+            <div id="athens-pin-layer"></div>
+          </div>
+          <canvas id="landmarks-canvas" aria-hidden="true"></canvas>
+        </div>
+      </div>
+      <div>
+        <div class="mini-map" id="mini-map" role="list" aria-label="Landmark categories"></div>
+        <p class="athens-mini-map-label mt-2">Dot colours: democracy (green), cultural (red), natural (blue).</p>
       </div>
     </section>
 
@@ -871,6 +915,150 @@ onAuthStateChanged(auth, async (user) => {
   // Save once on sign-in to create/update doc
   saveBundle();
 });
+</script>
+
+<script type="module">
+  import { createLandmarkOverlay } from './src/map/createOverlay.js';
+
+  const BOUNDS = {
+    minLon: 23.54,
+    maxLon: 23.75,
+    minLat: 37.93,
+    maxLat: 38.05
+  };
+
+  const canvas = document.getElementById('landmarks-canvas');
+  const overlay = createLandmarkOverlay
+    ? createLandmarkOverlay(canvas, {
+        geoJsonUrl: './data/athens_places.geojson',
+        agoraDataUrl: './data/agora_local.json',
+        showAgoraLayer: true
+      })
+    : new window.AthensMap.LandmarkOverlay(canvas, {
+        geoJsonUrl: './data/athens_places.geojson',
+        agoraDataUrl: './data/agora_local.json',
+        showAgoraLayer: true
+      });
+
+  overlay.initialize().catch(console.error);
+
+  const AGORA_BUILDING_STYLES = {
+    'Temple of Hephaistos': { width: 46, height: 20 },
+    'Stoa of Attalos': { width: 96, height: 18 },
+    Tholos: { width: 30, height: 30, borderRadius: '50%' },
+    Bouleuterion: { width: 36, height: 24 },
+    'Altar of the Twelve Gods': { width: 28, height: 16 }
+  };
+
+  let cachedFeatures = [];
+  let cachedAgoraFeatures = [];
+
+  function projectToMap([lon, lat], rect) {
+    const width = rect?.width || 1;
+    const height = rect?.height || 1;
+    const x = ((lon - BOUNDS.minLon) / (BOUNDS.maxLon - BOUNDS.minLon)) * width;
+    const y = (1 - (lat - BOUNDS.minLat) / (BOUNDS.maxLat - BOUNDS.minLat)) * height;
+    return [x, y];
+  }
+
+  function renderAgoraFeatures(features, rect) {
+    const layer = document.getElementById('athens-agora-layer');
+    if (!layer) return;
+    layer.innerHTML = '';
+    features.forEach((feature) => {
+      if (feature?.geometry?.type !== 'Point') return;
+      const title = feature?.properties?.title || feature?.properties?.name || 'Agora building';
+      const building = document.createElement('div');
+      building.className = 'athens-agora-building';
+      const cat = (feature?.properties?.category || 'cultural').toLowerCase();
+      building.dataset.category = cat;
+      const style = AGORA_BUILDING_STYLES[feature?.properties?.name] || {};
+      if (style.width) building.style.width = `${style.width}px`;
+      if (style.height) building.style.height = `${style.height}px`;
+      if (style.borderRadius) building.style.borderRadius = style.borderRadius;
+      const [x, y] = projectToMap(feature.geometry.coordinates, rect);
+      building.style.left = `${x}px`;
+      building.style.top = `${y}px`;
+      const label = document.createElement('span');
+      label.textContent = title;
+      building.appendChild(label);
+      layer.appendChild(building);
+    });
+  }
+
+  function renderPins(features, rect) {
+    const layer = document.getElementById('athens-pin-layer');
+    const mini = document.getElementById('mini-map');
+    if (!layer || !mini) return;
+    layer.innerHTML = '';
+    mini.innerHTML = '';
+
+    features.forEach((feature) => {
+      if (feature?.geometry?.type !== 'Point') return;
+      const title = feature?.properties?.title || feature?.properties?.name || 'Landmark';
+      const pin = document.createElement('div');
+      pin.className = 'athens-pin';
+      const label = document.createElement('span');
+      label.className = 'athens-pin-label';
+      label.textContent = title;
+      pin.appendChild(label);
+      const [x, y] = projectToMap(feature.geometry.coordinates, rect);
+      pin.style.left = `${x}px`;
+      pin.style.top = `${y}px`;
+      pin.setAttribute('role', 'img');
+      pin.setAttribute('aria-label', title);
+      layer.appendChild(pin);
+
+      const icon = document.createElement('div');
+      const cat = (feature?.properties?.category || 'cultural').toLowerCase();
+      icon.className = `map-icon map-icon-${cat}`;
+      icon.setAttribute('role', 'listitem');
+      icon.title = title;
+      mini.appendChild(icon);
+    });
+  }
+
+  function renderAll() {
+    const container = document.getElementById('athens-3d-layer');
+    if (!container) return;
+    const rect = { width: container.clientWidth || 1, height: container.clientHeight || 1 };
+    renderAgoraFeatures(cachedAgoraFeatures, rect);
+    renderPins(cachedFeatures, rect);
+  }
+
+  async function loadAthensGeo(force = false) {
+    if (!cachedFeatures.length || force) {
+      const res = await fetch('./data/athens_places.geojson');
+      if (!res.ok) {
+        throw new Error(`Failed to load GeoJSON: ${res.status}`);
+      }
+      const data = await res.json();
+      cachedFeatures = Array.isArray(data.features) ? data.features : [];
+    }
+    renderAll();
+    return cachedFeatures;
+  }
+
+  async function loadAgoraGeo(force = false) {
+    if (!cachedAgoraFeatures.length || force) {
+      try {
+        const res = await fetch('./data/agora_local.json');
+        if (!res.ok) throw new Error(`status ${res.status}`);
+        const data = await res.json();
+        cachedAgoraFeatures = Array.isArray(data.features) ? data.features : [];
+      } catch (err) {
+        console.warn('[athens] Failed to load Agora data', err);
+        cachedAgoraFeatures = [];
+      }
+    }
+    renderAll();
+    return cachedAgoraFeatures;
+  }
+
+  Promise.all([loadAthensGeo(), loadAgoraGeo()]).catch(console.error);
+  window.addEventListener('resize', renderAll);
+
+  window.loadAthensGeo = loadAthensGeo;
 </script>
 
 

--- a/src/map/createOverlay.js
+++ b/src/map/createOverlay.js
@@ -1,0 +1,7 @@
+import { LandmarkOverlay } from './landmarks.js';
+
+function createLandmarkOverlay(canvas, options = {}) {
+  return new LandmarkOverlay(canvas, options);
+}
+
+export { LandmarkOverlay, createLandmarkOverlay };

--- a/src/map/landmarks.js
+++ b/src/map/landmarks.js
@@ -1,0 +1,239 @@
+const LANDMARK_LABELS = {
+  'Acropolis': 'Acropolis',
+  'Agora': 'Agora',
+  'Pnyx': 'Pnyx',
+  'Areopagus': 'Areopagus',
+  'Kerameikos': 'Kerameikos',
+  'Parthenon': 'Parthenon',
+  'Erechtheion': 'Erechtheion',
+  'Propylaea': 'Propylaea',
+  'Temple of Athena Nike': 'Athena Nike',
+  'Theatre of Dionysus': 'Dionysus Theatre',
+  'Odeon of Herodes Atticus': 'Odeon',
+  'Temple of Olympian Zeus': 'Olympeion',
+  'Roman Agora': 'Roman Agora',
+  'Tower of the Winds': 'Tower of the Winds',
+  "Hadrian's Library": "Hadrian's Library",
+  'Panathenaic Stadium': 'Kallimarmaro',
+  'Temple of Hephaistos': 'Hephaistos',
+  'Stoa of Attalos': 'Stoa of Attalos',
+  'Tholos': 'Tholos',
+  'Bouleuterion': 'Bouleuterion',
+  'Altar of the Twelve Gods': 'Altar of the XII Gods',
+  'Sacred Way (Eleusis–Athens)': 'Sacred Way',
+  'Long Walls (Piraeus)': 'Piraeus Long Wall',
+  'Long Walls (Phaleron)': 'Phaleron Long Wall',
+  'City Wall of Athens': 'City Wall',
+  'Areopagus Viewpoint West': 'Areopagus View',
+  'Areopagus Viewpoint South': 'Areopagus View',
+  'Areopagus Viewpoint East': 'Areopagus View'
+};
+
+const LONG_WALL_LABELS = {
+  'Long Walls (Piraeus)': 'Long Walls to Piraeus',
+  'Long Walls (Phaleron)': 'Long Walls to Phaleron'
+};
+
+function getCanvasContext(canvas) {
+  if (!canvas) return null;
+  const ctx = canvas.getContext('2d');
+  if (!ctx) {
+    console.warn('[landmarks] Canvas 2D context unavailable');
+  }
+  return ctx;
+}
+
+function projectPoint([lon, lat], bounds, size) {
+  const baseLon = bounds?.lon ?? 23.72;
+  const baseLat = bounds?.lat ?? 37.97;
+  const scale = bounds?.scale ?? 12000;
+  const [width, height] = size;
+  const x = (lon - baseLon) * Math.cos((baseLat * Math.PI) / 180) * scale;
+  const y = -(lat - baseLat) * scale;
+  return [width / 2 + x, height / 2 + y];
+}
+
+class LandmarkOverlay {
+  constructor(canvas, options = {}) {
+    this.canvas = canvas;
+    this.ctx = getCanvasContext(canvas);
+    this.options = {
+      geoJsonUrl: './data/athens_places.geojson',
+      agoraDataUrl: null,
+      showAgoraLayer: false,
+      bounds: { lon: 23.72, lat: 37.97, scale: 12000 },
+      ...options
+    };
+    this.features = [];
+    this.agoraFeatures = [];
+    this.isReady = false;
+    if (canvas && typeof ResizeObserver !== 'undefined') {
+      this.resizeObserver = new ResizeObserver(() => this.render());
+      this.resizeObserver.observe(canvas);
+    }
+  }
+
+  async initialize() {
+    if (!this.canvas) {
+      throw new Error('LandmarkOverlay requires a canvas element');
+    }
+    await this.loadGeoJson(this.options.geoJsonUrl);
+    if (this.options.showAgoraLayer && this.options.agoraDataUrl) {
+      await this.loadAgoraLayer(this.options.agoraDataUrl);
+    }
+    this.isReady = true;
+    this.render();
+    return this;
+  }
+
+  async loadGeoJson(url) {
+    if (!url) return;
+    const res = await fetch(url);
+    if (!res.ok) {
+      throw new Error(`Failed to load GeoJSON from ${url}: ${res.status}`);
+    }
+    const data = await res.json();
+    this.features = Array.isArray(data.features) ? data.features : [];
+  }
+
+  async loadAgoraLayer(url) {
+    try {
+      const res = await fetch(url);
+      if (!res.ok) throw new Error(`status ${res.status}`);
+      const data = await res.json();
+      this.agoraFeatures = Array.isArray(data.features) ? data.features : [];
+    } catch (err) {
+      console.warn('[landmarks] Unable to load Agora layer', err);
+      this.agoraFeatures = [];
+    }
+  }
+
+  getLabelForFeature(f) {
+    const name = f?.properties?.name || '';
+    const short = LANDMARK_LABELS[name] || f?.properties?.short || f?.properties?.title || name;
+    return short || '';
+  }
+
+  render() {
+    if (!this.ctx || !this.canvas) return;
+    const ctx = this.ctx;
+    const width = (this.canvas.width = this.canvas.clientWidth || this.canvas.width || 640);
+    const height = (this.canvas.height = this.canvas.clientHeight || this.canvas.height || 480);
+    ctx.clearRect(0, 0, width, height);
+
+    const features = [...this.features];
+    if (this.options.showAgoraLayer && this.agoraFeatures.length) {
+      features.push(...this.agoraFeatures);
+    }
+    features.forEach((feature) => this.drawFeature(feature, width, height));
+  }
+
+  drawFeature(feature, width, height) {
+    const type = feature?.geometry?.type;
+    if (!type) return;
+    switch (type) {
+      case 'Point':
+        this.drawPoint(feature, width, height);
+        break;
+      case 'LineString':
+        this.drawLine(feature, width, height);
+        break;
+      case 'Polygon':
+        this.drawPolygon(feature, width, height);
+        break;
+      default:
+        break;
+    }
+  }
+
+  drawPoint(feature, width, height) {
+    const coordinates = feature.geometry.coordinates;
+    const [x, y] = projectPoint(coordinates, this.options.bounds, [width, height]);
+    const ctx = this.ctx;
+    ctx.save();
+    ctx.fillStyle = '#ef4444';
+    ctx.beginPath();
+    ctx.arc(x, y, 4, 0, Math.PI * 2);
+    ctx.fill();
+    const label = this.getLabelForFeature(feature);
+    if (label) {
+      ctx.font = '12px "Inter", system-ui, sans-serif';
+      ctx.fillStyle = 'rgba(17, 24, 39, 0.92)';
+      ctx.fillText(label, x + 6, y - 6);
+    }
+    ctx.restore();
+  }
+
+  drawLine(feature, width, height) {
+    const coords = feature.geometry.coordinates || [];
+    if (!coords.length) return;
+    const ctx = this.ctx;
+    ctx.save();
+    ctx.strokeStyle = '#2563eb';
+    ctx.lineWidth = 2;
+    ctx.setLineDash([6, 4]);
+    coords.forEach((pt, idx) => {
+      const [x, y] = projectPoint(pt, this.options.bounds, [width, height]);
+      if (idx === 0) ctx.moveTo(x, y);
+      else ctx.lineTo(x, y);
+    });
+    ctx.stroke();
+    ctx.setLineDash([]);
+    const midpoint = coords[Math.floor(coords.length / 2)];
+    const [mx, my] = projectPoint(midpoint, this.options.bounds, [width, height]);
+    const name = feature?.properties?.name;
+    const label = LONG_WALL_LABELS[name] || this.getLabelForFeature(feature);
+    if (label) {
+      ctx.font = '11px "Inter", system-ui, sans-serif';
+      ctx.fillStyle = 'rgba(30, 64, 175, 0.92)';
+      ctx.fillText(label, mx + 6, my - 6);
+    }
+    ctx.restore();
+  }
+
+  drawPolygon(feature, width, height) {
+    const rings = feature.geometry.coordinates || [];
+    if (!rings.length) return;
+    const ctx = this.ctx;
+    ctx.save();
+    ctx.fillStyle = 'rgba(96, 165, 250, 0.18)';
+    ctx.strokeStyle = 'rgba(59, 130, 246, 0.8)';
+    ctx.lineWidth = 1.5;
+    rings.forEach((ring) => {
+      ring.forEach((pt, idx) => {
+        const [x, y] = projectPoint(pt, this.options.bounds, [width, height]);
+        if (idx === 0) ctx.moveTo(x, y);
+        else ctx.lineTo(x, y);
+      });
+    });
+    ctx.closePath();
+    ctx.fill('nonzero');
+    ctx.stroke();
+    const firstRing = rings[0] || [];
+    const centroid = firstRing.reduce((acc, pt) => [acc[0] + pt[0], acc[1] + pt[1]], [0, 0]);
+    if (firstRing.length) {
+      centroid[0] /= firstRing.length;
+      centroid[1] /= firstRing.length;
+      const [cx, cy] = projectPoint(centroid, this.options.bounds, [width, height]);
+      const label = this.getLabelForFeature(feature);
+      if (label) {
+        ctx.font = '11px "Inter", system-ui, sans-serif';
+        ctx.fillStyle = 'rgba(37, 99, 235, 0.95)';
+        ctx.fillText(label, cx + 6, cy - 6);
+      }
+    }
+    ctx.restore();
+  }
+}
+
+function createLandmarkOverlay(canvas, options) {
+  return new LandmarkOverlay(canvas, options);
+}
+
+export { LandmarkOverlay, createLandmarkOverlay, LANDMARK_LABELS, LONG_WALL_LABELS };
+
+if (typeof window !== 'undefined') {
+  window.AthensMap = window.AthensMap || {};
+  window.AthensMap.LandmarkOverlay = LandmarkOverlay;
+  window.AthensMap.createLandmarkOverlay = createLandmarkOverlay;
+}


### PR DESCRIPTION
## Summary
- expand the GeoJSON dataset with detailed Athens monuments, Long Walls, and Sacred Way features plus Agora building points
- extend the landmark overlay to support new labels and fallback titles, and expose a factory helper
- embed an Athens explorer section that initialises the overlay, renders category-coloured pins/mini-map icons, and shows Agora building footprints

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_b_68d137bb9f348327a71c4b1e514054f9