### PR TITLE
Add student portfolio section with Firebase autosave

### DIFF
--- a/index.html
+++ b/index.html
@@ -172,6 +172,37 @@
       </div>
     </section>
 
+    <section id="portfolio" class="activity-card">
+      <div class="flex items-center justify-between mb-3">
+        <h2 class="text-2xl font-extrabold">📁 Portfolio — Unit Work</h2>
+        <span id="portfolioStatus" class="text-sm text-slate-500">Not signed in</span>
+      </div>
+
+      <!-- Unit / Week selectors -->
+      <div class="flex flex-wrap items-center gap-2 mb-4">
+        <label class="text-sm">
+          Unit:
+          <select id="pfUnit" class="ml-2 rounded-lg border border-slate-300 p-2">
+            <option value="civics-constitution-2025">Civics: Australia’s Constitution (2025)</option>
+          </select>
+        </label>
+        <div id="pfWeeks" class="flex flex-wrap gap-2"></div>
+      </div>
+
+      <!-- Prompts for the selected week -->
+      <div id="pfPrompts" class="grid gap-3"></div>
+
+      <!-- Uploads -->
+      <div class="mt-4">
+        <h3 class="font-semibold mb-2">Attachments</h3>
+        <div class="flex flex-wrap items-center gap-2 mb-2">
+          <input id="pfFile" type="file" multiple accept="image/*,application/pdf" class="block text-sm" />
+          <button id="pfUpload" class="px-3 py-2 rounded-lg border border-slate-300 text-sm">Upload</button>
+        </div>
+        <ul id="pfFiles" class="list-disc list-inside text-sm text-slate-700"></ul>
+      </div>
+    </section>
+
     <!-- Activity 1: Whiteboard “Big Paper” (same-origin embed) -->
     <section id="activity-1" class="activity-card">
       <div class="flex items-start">
@@ -1076,6 +1107,239 @@ onAuthStateChanged(auth, async (user) => {
 
   window.dispatchEvent(new CustomEvent('auth-ready', { detail: { user } }));
 });
+</script>
+
+<script type="module">
+  // Firebase (re-use your app if already initialized)
+  import { initializeApp, getApps, getApp } from 'https://www.gstatic.com/firebasejs/10.12.2/firebase-app.js';
+  import { getAuth, onAuthStateChanged } from 'https://www.gstatic.com/firebasejs/10.12.2/firebase-auth.js';
+  import {
+    getFirestore, doc, getDoc, setDoc, serverTimestamp
+  } from 'https://www.gstatic.com/firebasejs/10.12.2/firebase-firestore.js';
+  import {
+    getStorage, ref, uploadBytes, getDownloadURL, listAll, deleteObject
+  } from 'https://www.gstatic.com/firebasejs/10.12.2/firebase-storage.js';
+
+  // === Your config (public) — keep consistent with the rest of your page ===
+  const firebaseConfig = {
+    apiKey: "AIzaSyBrFrkNcIq7LL7dMvpG3ZUgNsYXs6hBTQY",
+    authDomain: "save-a9ea5.firebaseapp.com",
+    projectId: "save-a9ea5",
+    storageBucket: "save-a9ea5.firebasestorage.app",
+    messagingSenderId: "266526082951",
+    appId: "1:266526082951:web:dea4164197d3ff3f02f522"
+  };
+
+  const app = getApps().length ? getApp() : initializeApp(firebaseConfig);
+  const auth = getAuth(app);
+  const db = getFirestore(app);
+  const storage = getStorage(app);
+
+  // ====== Configure your Unit + Weeks here (edit labels/prompts freely) ======
+  const UNIT = {
+    id: 'civics-constitution-2025',
+    title: "Civics: Australia’s Constitution (2025)",
+    weeks: [
+      {
+        id: 'wk1', label: 'Week 1 — Vibe vs Text',
+        prompts: [
+          { id: 'sepPowers', label: 'Five-Finger: Separation of Powers' },
+          { id: 'divPowers', label: 'Five-Finger: Division of Powers' },
+          { id: 'ruleOfLaw', label: 'Five-Finger: Rule of Law' },
+          { id: 'repResp',   label: 'Five-Finger: Representative & Responsible Government' },
+          { id: 'rights',    label: 'Five-Finger: Rights in the Constitution' },
+          { id: 'reflection',label: 'Reflection — What surprised you? What’s missing?' }
+        ]
+      },
+      {
+        id: 'wk2', label: 'Week 2 — How the High Court interprets the Constitution',
+        prompts: [
+          { id: 'caseStudy', label: 'Case study: What happened and why?' },
+          { id: 'evidence',  label: 'Evidence from sources (quotes/notes)' },
+          { id: 'reflection',label: 'Reflection — What did this change or clarify?' }
+        ]
+      },
+      {
+        id: 'wk3', label: 'Week 3 — Comparing Constitutions (AUS vs another)',
+        prompts: [
+          { id: 'similar',   label: 'Similarities' },
+          { id: 'different', label: 'Differences' },
+          { id: 'impact',    label: 'Impact on people/government' }
+        ]
+      },
+      {
+        id: 'wk4', label: 'Week 4 — Rights Debate',
+        prompts: [
+          { id: 'pros',      label: 'Arguments for a Bill of Rights in AUS' },
+          { id: 'cons',      label: 'Arguments against' },
+          { id: 'position',  label: 'Your position + reasons' }
+        ]
+      },
+      {
+        id: 'wk5', label: 'Week 5 — Assessment Prep',
+        prompts: [
+          { id: 'thesis',    label: 'Thesis / main claim' },
+          { id: 'evidence',  label: 'Key evidence' },
+          { id: 'counter',   label: 'Counterargument + rebuttal' }
+        ]
+      },
+      {
+        id: 'wk6', label: 'Week 6 — Final Reflection',
+        prompts: [
+          { id: 'lookBack',  label: 'How did your understanding change?' },
+          { id: 'strengths', label: 'Your strengths in this unit' },
+          { id: 'goals',     label: 'Goals for next unit' }
+        ]
+      }
+    ]
+  };
+
+  // ====== Elements ======
+  const statusEl = document.getElementById('portfolioStatus');
+  const unitSel  = document.getElementById('pfUnit');
+  const weekTabs = document.getElementById('pfWeeks');
+  const promptsEl= document.getElementById('pfPrompts');
+  const fileInput= document.getElementById('pfFile');
+  const uploadBtn= document.getElementById('pfUpload');
+  const filesList= document.getElementById('pfFiles');
+
+  // ====== State ======
+  let currentUser = null;
+  let currentWeekId = localStorage.getItem('pf_week') || UNIT.weeks[0].id;
+
+  // ====== Helpers ======
+  const weekById = id => UNIT.weeks.find(w => w.id === id);
+  const weekDoc = (uid, weekId) => doc(db, 'portfolios', uid, 'units', UNIT.id, 'weeks', weekId);
+  const storageKey = (uid, weekId, name) => `uploads/${uid}/${UNIT.id}/${weekId}/${Date.now()}_${name.replace(/\s+/g,'_')}`;
+
+  function renderWeekTabs() {
+    weekTabs.innerHTML = '';
+    UNIT.weeks.forEach(w => {
+      const btn = document.createElement('button');
+      btn.className = `px-3 py-1 rounded-full border ${w.id===currentWeekId ? 'bg-blue-600 text-white' : 'hover:bg-slate-50'}`;
+      btn.textContent = w.label;
+      btn.onclick = () => {
+        currentWeekId = w.id;
+        localStorage.setItem('pf_week', currentWeekId);
+        renderWeekTabs();
+        loadWeek();
+      };
+      weekTabs.appendChild(btn);
+    });
+  }
+
+  function mountPrompts(data) {
+    promptsEl.innerHTML = '';
+    const week = weekById(currentWeekId);
+    week.prompts.forEach(p => {
+      const wrap = document.createElement('div');
+      wrap.className = 'bg-slate-50 border border-slate-200 rounded-lg p-3';
+      wrap.innerHTML = `
+        <label class="block text-sm font-semibold mb-1">${p.label}</label>
+        <textarea data-prompt="${p.id}" rows="4"
+          class="w-full rounded-lg border border-slate-300 p-2"
+          placeholder="Type here..."></textarea>
+      `;
+      const ta = wrap.querySelector('textarea');
+      ta.value = (data?.panels?.[p.id]) || '';
+      ta.addEventListener('input', debounce(saveWeek, 800));
+      ta.addEventListener('blur', saveWeek);
+      promptsEl.appendChild(wrap);
+    });
+  }
+
+  async function loadWeek() {
+    filesList.innerHTML = '';
+    if (!currentUser) return;
+    const ref = weekDoc(currentUser.uid, currentWeekId);
+    const snap = await getDoc(ref);
+    const data = snap.exists() ? snap.data() : null;
+    mountPrompts(data);
+    await refreshFiles();
+  }
+
+  async function saveWeek() {
+    if (!currentUser) return;
+    const panels = {};
+    promptsEl.querySelectorAll('textarea[data-prompt]').forEach(ta => {
+      panels[ta.getAttribute('data-prompt')] = ta.value.trim();
+    });
+    const ref = weekDoc(currentUser.uid, currentWeekId);
+    await setDoc(ref, {
+      uid: currentUser.uid,
+      unitId: UNIT.id,
+      weekId: currentWeekId,
+      panels,
+      updatedAt: serverTimestamp()
+    }, { merge: true });
+    statusEl.textContent = 'Saved';
+    setTimeout(()=> statusEl.textContent = 'Saved (signed in)', 1500);
+  }
+
+  // Files
+  async function refreshFiles() {
+    filesList.innerHTML = '';
+    const base = `uploads/${currentUser.uid}/${UNIT.id}/${currentWeekId}`;
+    const dirRef = ref(storage, base);
+    try {
+      const listing = await listAll(dirRef);
+      if (listing.items.length === 0) {
+        filesList.innerHTML = '<li class="text-slate-500">No files yet.</li>';
+        return;
+      }
+      for (const item of listing.items) {
+        const url = await getDownloadURL(item);
+        const li = document.createElement('li');
+        li.innerHTML = `
+          <a class="underline" target="_blank" rel="noopener" href="${url}">${item.name}</a>
+          <button class="ml-2 text-xs underline text-rose-600" data-del>Delete</button>
+        `;
+        li.querySelector('[data-del]').onclick = async () => {
+          if (!confirm('Delete this file from your portfolio?')) return;
+          await deleteObject(item);
+          await refreshFiles();
+        };
+        filesList.appendChild(li);
+      }
+    } catch (e) {
+      filesList.innerHTML = '<li class="text-rose-600">Can’t list files (are Storage rules set?)</li>';
+      console.error(e);
+    }
+  }
+
+  uploadBtn?.addEventListener('click', async () => {
+    if (!currentUser) return alert('Sign in first.');
+    const files = fileInput.files;
+    if (!files || !files.length) return alert('Choose one or more files first.');
+    for (const f of files) {
+      const path = storageKey(currentUser.uid, currentWeekId, f.name);
+      const r = ref(storage, path);
+      await uploadBytes(r, f);
+    }
+    fileInput.value = '';
+    await refreshFiles();
+  });
+
+  // Tiny debounce
+  function debounce(fn, ms) {
+    let t; return (...a) => { clearTimeout(t); t=setTimeout(()=>fn(...a), ms); };
+  }
+
+  // Auth link-up (expects you already wired Google sign-in somewhere else on the page)
+  onAuthStateChanged(auth, async (user) => {
+    currentUser = user || null;
+    if (!user) {
+      statusEl.textContent = 'Not signed in';
+      promptsEl.innerHTML = '<div class="text-sm text-slate-600">Sign in with your school account to start/continue your portfolio.</div>';
+      return;
+    }
+    statusEl.textContent = 'Saved (signed in)';
+    unitSel.value = UNIT.id;
+    renderWeekTabs();
+    await loadWeek();
+  });
+
+  // if you add more units later, you can read unitSel.value and swap UNIT dynamically.
 </script>
 
 


### PR DESCRIPTION
## Summary
- add a portfolio section beneath the intro so students can pick a unit week, record their responses, and manage attachments
- implement Firebase autosave logic that stores weekly panels in Firestore and uploads files to Firebase Storage per student/week

## Testing
- Not run (static site changes)


------
https://chatgpt.com/codex/tasks/task_b_68d14c1573d88327beb5a30bf78a43e6