### PR TITLE
Add accessible dropdown navigation for portfolio

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,6 +30,193 @@
     .lift:hover { transform: translateY(-4px); box-shadow: 0 24px 40px rgba(2,6,23,.12); }
     @media (prefers-reduced-motion: reduce) { .lift { transition: none; } }
 
+    /* Primary navigation */
+    .site-nav {
+      display:flex;
+      align-items:center;
+      gap:1.25rem;
+      justify-content:flex-start;
+      padding:.75rem 0;
+      position:relative;
+      z-index:30;
+    }
+    .site-nav .brand {
+      display:inline-flex;
+      align-items:center;
+      gap:.75rem;
+      font-weight:700;
+      text-decoration:none;
+      color:#111;
+    }
+    .site-nav .brand-mark {
+      width:2rem;
+      height:2rem;
+      border-radius:.9rem;
+      background:linear-gradient(135deg,#3b82f6,#2563eb);
+      flex-shrink:0;
+    }
+    .site-nav .brand-text {
+      font-weight:800;
+      letter-spacing:-.01em;
+    }
+    .nav-toggle {
+      display:none;
+      background:none;
+      border:1px solid #ddd;
+      padding:.35rem .6rem;
+      border-radius:.5rem;
+      cursor:pointer;
+      font-size:1.25rem;
+      line-height:1;
+    }
+    .nav-links {
+      display:flex;
+      align-items:center;
+      gap:1rem;
+      list-style:none;
+      margin:0;
+      padding:0;
+      margin-left:auto;
+    }
+    .nav-links > li {
+      position:relative;
+      display:flex;
+      align-items:center;
+    }
+    .nav-links a,
+    .dropdown-btn {
+      text-decoration:none;
+      color:#222;
+      padding:.4rem .65rem;
+      border-radius:.4rem;
+      font-weight:500;
+    }
+    .nav-links a:hover,
+    .dropdown-btn:hover {
+      background:#f2f2f2;
+    }
+    .dropdown { position:relative; }
+    .dropdown-btn {
+      background:none;
+      border:none;
+      cursor:pointer;
+      display:inline-flex;
+      align-items:center;
+      gap:.25rem;
+    }
+    .dropdown-menu {
+      position:absolute;
+      top:calc(100% + .25rem);
+      left:0;
+      min-width:260px;
+      max-width:88vw;
+      background:#fff;
+      border:1px solid #e6e6e6;
+      border-radius:.5rem;
+      box-shadow:0 6px 28px rgba(0,0,0,.08);
+      list-style:none;
+      margin:0;
+      padding:.4rem;
+      display:none;
+      z-index:40;
+    }
+    .dropdown-menu a {
+      display:block;
+      padding:.5rem .6rem;
+      border-radius:.35rem;
+      white-space:nowrap;
+      overflow:hidden;
+      text-overflow:ellipsis;
+      color:#222;
+    }
+    .dropdown-menu a:hover { background:#f7f7f7; }
+    .dropdown.open > .dropdown-menu { display:block; }
+    .nav-links > .nav-utilities {
+      display:flex;
+      align-items:center;
+      gap:.75rem;
+      margin-left:1rem;
+    }
+    .nav-links > .nav-utilities .nav-auth {
+      display:flex;
+      align-items:center;
+      gap:.5rem;
+    }
+    .nav-links > .nav-utilities .theme-toggle { flex-shrink:0; }
+    @media (max-width: 820px) {
+      .site-nav { flex-wrap:wrap; }
+      .nav-toggle {
+        display:inline-flex;
+        align-items:center;
+        justify-content:center;
+      }
+      .nav-links {
+        position:absolute;
+        top:100%;
+        left:0;
+        right:0;
+        background:#fff;
+        border-bottom:1px solid #e6e6e6;
+        flex-direction:column;
+        align-items:stretch;
+        gap:.25rem;
+        padding:.75rem 1rem 1rem;
+        display:none;
+        z-index:50;
+      }
+      .nav-links.open { display:flex; }
+      .nav-links > li { width:100%; }
+      .nav-links a,
+      .dropdown-btn { width:100%; }
+      .dropdown-menu {
+        position:static;
+        box-shadow:none;
+        border:none;
+        padding-left:.5rem;
+      }
+      .dropdown-btn {
+        justify-content:space-between;
+        text-align:left;
+      }
+      .nav-links > .nav-utilities {
+        flex-direction:column;
+        align-items:stretch;
+        gap:.75rem;
+        padding-top:.75rem;
+        margin-top:.5rem;
+        border-top:1px solid #e6e6e6;
+      }
+      .nav-links > .nav-utilities .nav-auth {
+        flex-direction:column;
+        align-items:stretch;
+      }
+      .nav-links > .nav-utilities .nav-auth button { width:100%; }
+      .nav-links > .nav-utilities .theme-toggle { align-self:flex-start; }
+      .dark .nav-links {
+        background:#0f172a;
+        border-color:rgba(148,163,184,.35);
+      }
+      .dark .nav-links > .nav-utilities {
+        border-top-color:rgba(148,163,184,.35);
+      }
+    }
+    .dark .site-nav .brand,
+    .dark .nav-links a,
+    .dark .dropdown-btn {
+      color:#f1f5f9;
+    }
+    .dark .nav-links a:hover,
+    .dark .dropdown-btn:hover {
+      background:rgba(148,163,184,.2);
+    }
+    .dark .dropdown-menu {
+      background:#0f172a;
+      border-color:rgba(148,163,184,.35);
+      box-shadow:0 12px 32px rgba(15,23,42,.45);
+    }
+    .dark .dropdown-menu a { color:#f1f5f9; }
+    .dark .dropdown-menu a:hover { background:rgba(148,163,184,.25); }
+
     .activity-card{
       background:linear-gradient(135deg,rgba(219,234,254,.55),rgba(248,250,252,.92));
       border-radius:1rem;padding:1.5rem;margin-bottom:1.25rem;
@@ -72,52 +259,61 @@
 
   <!-- Header / Nav -->
   <header class="sticky top-0 z-40 backdrop-blur supports-[backdrop-filter]:bg-white/70 dark:supports-[backdrop-filter]:bg-slate-900/70 border-b border-slate-200/60 dark:border-slate-800">
-    <div class="container flex h-16 items-center justify-between">
-      <a href="#" class="flex items-center gap-3">
-        <div class="h-8 w-8 rounded-xl bg-brand-600"></div>
-        <span class="font-extrabold tracking-tight">Civics Toolkit</span>
-      </a>
-      <nav class="hidden md:flex items-center gap-6 text-sm">
-        <a href="#activity-1" class="hover:text-brand-600">Big Paper</a>
-        <a href="#activity-2" class="hover:text-brand-600">Real Deal</a>
-        <a href="#activity-3" class="hover:text-brand-600">Showdown</a>
-        <a href="#activity-4" class="hover:text-brand-600">Game</a>
-        <a href="#resources" class="hover:text-brand-600">Resources</a>
+    <div class="container">
+      <nav class="site-nav">
+        <a class="brand" href="#overview">
+          <span class="brand-mark" aria-hidden="true"></span>
+          <span class="brand-text">Civics Toolkit</span>
+        </a>
+
+        <button class="nav-toggle" aria-label="Toggle menu" aria-expanded="false">
+          ☰
+        </button>
+
+        <ul class="nav-links" data-collapsible>
+          <li><a href="#overview">Overview</a></li>
+
+          <li class="dropdown">
+            <button class="dropdown-btn"
+                    aria-haspopup="true"
+                    aria-expanded="false"
+                    aria-controls="portfolio-menu">
+              Portfolio of Work ▼
+            </button>
+            <ul id="portfolio-menu" class="dropdown-menu" role="menu">
+              <li role="none"><a role="menuitem" href="#portfolio">Portfolio Hub</a></li>
+              <li role="none"><a role="menuitem" href="whiteboard/index.html">Activity 1: Whiteboard</a></li>
+              <li role="none"><a role="menuitem" href="#activity-2">Activity 2: Video + Reflection</a></li>
+              <li role="none"><a role="menuitem" href="#activity-3">Activity 3: Reflection Panel</a></li>
+              <li role="none"><a role="menuitem" href="#activity-4">Activity 4: Constitution Game</a></li>
+            </ul>
+          </li>
+
+          <li><a href="#resources">Resources</a></li>
+          <li><a href="#save-online">Save Online</a></li>
+
+          <li class="nav-utilities" role="none">
+            <div id="authArea" class="nav-auth flex items-center gap-2" role="none">
+              <button id="googleLoginTop"
+                      class="px-3 py-2 rounded-lg bg-brand-600 text-white font-semibold hover:opacity-90">
+                Sign in with Google
+              </button>
+              <button id="signOutTop"
+                      class="hidden px-3 py-2 rounded-lg border border-slate-300 text-sm hover:bg-slate-50">
+                Sign out
+              </button>
+            </div>
+            <button id="themeToggle" class="theme-toggle p-2 rounded-lg hover:bg-slate-100 dark:hover:bg-slate-800" aria-label="Toggle dark mode">
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="h-5 w-5"><path d="M21.75 15.002A9.72 9.72 0 0 1 12.004 22C6.487 22 2 17.513 2 11.996 2 7.45 4.94 3.61 9.06 2.248a.75.75 0 0 1 .935.966 8.25 8.25 0 0 0 10.73 10.73.75.75 0 0 1 1.027.958Z"/></svg>
+            </button>
+          </li>
+        </ul>
       </nav>
-      <div class="flex items-center gap-3">
-        <!-- AUTH MOUNT -->
-        <div id="authArea" class="flex items-center gap-2">
-          <button id="googleLoginTop"
-                  class="px-3 py-2 rounded-lg bg-brand-600 text-white font-semibold hover:opacity-90">
-            Sign in with Google
-          </button>
-          <button id="signOutTop"
-                  class="hidden px-3 py-2 rounded-lg border border-slate-300 text-sm hover:bg-slate-50">
-            Sign out
-          </button>
-        </div>
-        <button id="themeToggle" class="p-2 rounded-lg hover:bg-slate-100 dark:hover:bg-slate-800" aria-label="Toggle dark mode">
-          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="h-5 w-5"><path d="M21.75 15.002A9.72 9.72 0 0 1 12.004 22C6.487 22 2 17.513 2 11.996 2 7.45 4.94 3.61 9.06 2.248a.75.75 0 0 1 .935.966 8.25 8.25 0 0 0 10.73 10.73.75.75 0 0 1 1.027.958Z"/></svg>
-        </button>
-        <button id="menuBtn" class="md:hidden p-2 rounded-lg hover:bg-slate-100 dark:hover:bg-slate-800" aria-label="Open menu">
-          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="h-6 w-6"><path d="M3.75 5.25h16.5v1.5H3.75zM3.75 11.25h16.5v1.5H3.75zM3.75 17.25h16.5v1.5H3.75z"/></svg>
-        </button>
-      </div>
-    </div>
-    <!-- Mobile menu -->
-    <div id="mobileMenu" class="md:hidden hidden border-t border-slate-200/60 dark:border-slate-800">
-      <div class="container py-3 grid gap-3">
-        <a href="#activity-1" class="py-2">Big Paper</a>
-        <a href="#activity-2" class="py-2">Real Deal</a>
-        <a href="#activity-3" class="py-2">Showdown</a>
-        <a href="#activity-4" class="py-2">Game</a>
-        <a href="#resources" class="py-2">Resources</a>
-      </div>
     </div>
   </header>
 
   <!-- Hero -->
-  <section class="relative overflow-hidden">
+  <section id="overview" class="relative overflow-hidden">
     <div class="absolute inset-0 -z-10 bg-gradient-to-b from-white via-brand-50 to-white dark:from-slate-950 dark:via-slate-900 dark:to-slate-950"></div>
     <div class="container grid md:grid-cols-2 gap-10 py-14 md:py-20 items-center">
       <div>
@@ -483,26 +679,97 @@
 
   <!-- Nav + Dark mode + Footer year -->
   <script>
-    // Mobile menu
-    const menuBtn = document.getElementById('menuBtn');
-    const mobileMenu = document.getElementById('mobileMenu');
-    menuBtn?.addEventListener('click', () => mobileMenu.classList.toggle('hidden'));
+    (function () {
+      const nav = document.querySelector('.site-nav');
+      const navToggle = nav?.querySelector('.nav-toggle');
+      const navLinks = nav?.querySelector('.nav-links');
+      const dropdown = nav?.querySelector('.dropdown');
+      const dropBtn = dropdown?.querySelector('.dropdown-btn');
+      const menu = document.getElementById('portfolio-menu');
 
-    // Dark mode (persist)
-    const toggle = document.getElementById('themeToggle');
-    const root = document.documentElement;
-    const KEY = 'theme';
-    const saved = localStorage.getItem(KEY);
-    if (saved === 'dark' || (!saved && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
-      root.classList.add('dark');
-    }
-    toggle?.addEventListener('click', () => {
-      root.classList.toggle('dark');
-      localStorage.setItem(KEY, root.classList.contains('dark') ? 'dark' : 'light');
-    });
+      function toggleDropdown(force) {
+        if (!dropdown || !dropBtn) return;
+        const isOpen = dropdown.classList.contains('open');
+        const shouldOpen = typeof force === 'boolean' ? force : !isOpen;
+        dropdown.classList.toggle('open', shouldOpen);
+        dropBtn.setAttribute('aria-expanded', String(shouldOpen));
+      }
 
-    // Footer year
-    document.getElementById('year').textContent = new Date().getFullYear();
+      function setNavOpen(open) {
+        if (!navLinks) return;
+        navLinks.classList.toggle('open', open);
+        navToggle?.setAttribute('aria-expanded', String(open));
+        if (!open) toggleDropdown(false);
+      }
+
+      navToggle?.addEventListener('click', (event) => {
+        event.stopPropagation();
+        const open = !navLinks?.classList.contains('open');
+        setNavOpen(open);
+      });
+
+      navLinks?.addEventListener('click', (event) => {
+        const target = event.target instanceof Element ? event.target.closest('a') : null;
+        if (target) setNavOpen(false);
+      });
+
+      dropBtn?.addEventListener('click', (event) => {
+        event.stopPropagation();
+        toggleDropdown();
+      });
+
+      dropBtn?.addEventListener('keydown', (event) => {
+        if (event.key === 'Enter' || event.key === ' ' || event.key === 'Spacebar') {
+          event.preventDefault();
+          toggleDropdown();
+        } else if (event.key === 'ArrowDown') {
+          event.preventDefault();
+          toggleDropdown(true);
+          const firstLink = menu?.querySelector('a');
+          if (firstLink) firstLink.focus();
+        }
+      });
+
+      document.addEventListener('click', (event) => {
+        if (dropdown && !dropdown.contains(event.target)) toggleDropdown(false);
+        if (nav && navLinks?.classList.contains('open') && !nav.contains(event.target)) {
+          setNavOpen(false);
+        }
+      });
+
+      document.addEventListener('keydown', (event) => {
+        if (event.key === 'Escape') {
+          toggleDropdown(false);
+          setNavOpen(false);
+        }
+      });
+    })();
+
+    (function () {
+      const toggle = document.getElementById('themeToggle');
+      const root = document.documentElement;
+      const KEY = 'theme';
+      let savedTheme = null;
+      try {
+        savedTheme = localStorage.getItem(KEY);
+      } catch (err) {
+        savedTheme = null;
+      }
+      if (savedTheme === 'dark' || (!savedTheme && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
+        root.classList.add('dark');
+      }
+      toggle?.addEventListener('click', () => {
+        root.classList.toggle('dark');
+        try {
+          localStorage.setItem(KEY, root.classList.contains('dark') ? 'dark' : 'light');
+        } catch (err) {
+          /* ignore */
+        }
+      });
+    })();
+
+    const yearEl = document.getElementById('year');
+    if (yearEl) yearEl.textContent = new Date().getFullYear();
   </script>
 
   <!-- Writing panels autosave -->


### PR DESCRIPTION
## Summary
- replace the existing header with an accessible navigation bar that includes a Portfolio of Work dropdown and mobile toggle
- add dedicated CSS styling to support the new navigation layout, login buttons, and dark theme states
- update page scripts to handle dropdown behavior, mobile menu toggling, and keep dark mode persistence plus footer year updates

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68d1b341c2d08327bac7bb3ee43806ee