### PR TITLE
Add Google Docs integration scaffolding

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -1,0 +1,69 @@
+/**
+ * Quick start:
+ * 1) In Google Cloud Console, enable APIs: Docs API + Drive API
+ * 2) Share students' Docs or the target folder with your Firebase service account:
+ *    {project-id}@appspot.gserviceaccount.com  (Editor)
+ * 3) Deploy: firebase deploy --only functions
+ *
+ * Frontend will call: httpsCallable('transferToDoc') with { content }
+ *
+ * README-style checklist:
+ * - Enable Docs + Drive APIs for the Firebase project.
+ * - Share each student Doc with {project-id}@appspot.gserviceaccount.com (Editor).
+ * - Deploy via `cd functions && npm i && firebase deploy --only functions`.
+ * - Update the Firebase web config injected on week1.html.
+ */
+
+const { onCall } = require("firebase-functions/v2/https");
+const { getApp, getApps, initializeApp } = require("firebase-admin/app");
+const { getFirestore } = require("firebase-admin/firestore");
+const { google } = require("googleapis");
+const { GoogleAuth } = require("googleapis-common");
+
+if (!getApps().length) initializeApp();
+
+async function getClients() {
+  const auth = new GoogleAuth({
+    scopes: [
+      "https://www.googleapis.com/auth/documents",
+      "https://www.googleapis.com/auth/drive"
+    ],
+  });
+  const client = await auth.getClient();
+  return {
+    docs: google.docs({ version: "v1", auth: client }),
+  };
+}
+
+const safe = (s) => (typeof s === "string" ? s : "");
+
+exports.transferToDoc = onCall({ cors: true }, async (req) => {
+  const uid = req.auth?.uid;
+  const email = req.auth?.token?.email || "Student";
+  if (!uid) throw new Error("Unauthenticated.");
+
+  const content = safe(req.data?.content);
+  if (!content) throw new Error("No content.");
+
+  const db = getFirestore();
+  const userSnap = await db.doc(`users/${uid}`).get();
+  if (!userSnap.exists) throw new Error("No user profile found.");
+  const docId = userSnap.data()?.docId;
+  if (!docId) throw new Error("No Google Doc saved for this user.");
+
+  const { docs } = await getClients();
+  const now = new Date().toISOString();
+  const header = `Submission from ${email} — ${now}\n\n`;
+
+  // Append at end (avoids overwriting teacher instructions)
+  await docs.documents.batchUpdate({
+    documentId: docId,
+    requestBody: {
+      requests: [
+        { insertText: { endOfSegmentLocation: {}, text: header + content + "\n\n" } }
+      ]
+    }
+  });
+
+  return { ok: true };
+});

--- a/functions/package.json
+++ b/functions/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "civics-doc-writer",
+  "private": true,
+  "engines": { "node": ">=18" },
+  "scripts": {
+    "build": "echo \"no build\"",
+    "deploy": "firebase deploy --only functions",
+    "serve": "firebase emulators:start --only functions"
+  },
+  "dependencies": {
+    "firebase-admin": "^12.6.0",
+    "firebase-functions": "^5.0.1",
+    "googleapis": "^131.0.0"
+  }
+}

--- a/js/app-docs.js
+++ b/js/app-docs.js
@@ -1,0 +1,106 @@
+// js/app-docs.js
+// Minimal client for "Save Doc URL" + "Send to Google Doc"
+
+// ---- CONFIG ----
+// Either edit here, or inject via <script> that defines window.__firebase_config_json
+const DEFAULT_CONFIG = {
+  // TODO: replace with your Firebase web app keys
+  apiKey: "YOUR_API_KEY",
+  authDomain: "YOUR_PROJECT.firebaseapp.com",
+  projectId: "YOUR_PROJECT",
+  appId: "YOUR_APP_ID"
+};
+
+// DOM ids expected to exist in week1.html
+const EL_IDS = {
+  docUrlInput: "gcDocUrl",
+  saveBtn: "gcSaveDocBtn",
+  workInput: "gcWorkInput",
+  sendBtn: "gcSendBtn",
+  status: "portfolioStatus"
+};
+
+(async function init() {
+  const cfg = window.__firebase_config_json ? JSON.parse(window.__firebase_config_json) : DEFAULT_CONFIG;
+
+  const { initializeApp } = await import("https://www.gstatic.com/firebasejs/11.6.1/firebase-app.js");
+  const { getAuth, GoogleAuthProvider, signInWithPopup, onAuthStateChanged, signOut } =
+    await import("https://www.gstatic.com/firebasejs/11.6.1/firebase-auth.js");
+  const { getFirestore, doc, setDoc, getDoc } =
+    await import("https://www.gstatic.com/firebasejs/11.6.1/firebase-firestore.js");
+  const { getFunctions, httpsCallable } =
+    await import("https://www.gstatic.com/firebasejs/11.6.1/firebase-functions.js");
+
+  const app = initializeApp(cfg);
+  const auth = getAuth(app);
+  const db = getFirestore(app);
+  const functions = getFunctions(app);
+  const callTransfer = httpsCallable(functions, "transferToDoc");
+
+  const el = {};
+  for (const k of Object.keys(EL_IDS)) el[k] = document.getElementById(EL_IDS[k]);
+
+  // Simple auth UI hooks (optional: wire to your existing buttons)
+  const topLoginBtn = document.getElementById("googleLoginTop");
+  const topSignOutBtn = document.getElementById("signOutTop");
+
+  const provider = new GoogleAuthProvider();
+
+  async function ensureLogin() {
+    if (auth.currentUser) return auth.currentUser;
+    const { user } = await signInWithPopup(auth, provider);
+    return user;
+  }
+
+  function updateStatus(text) {
+    if (el.status) el.status.textContent = text;
+  }
+
+  onAuthStateChanged(auth, async (user) => {
+    if (user) {
+      updateStatus(`Signed in as ${user.email}`);
+      if (topLoginBtn) topLoginBtn.classList.add("hidden");
+      if (topSignOutBtn) topSignOutBtn.classList.remove("hidden");
+
+      // Load saved Doc ID to show a friendly message
+      const snap = await getDoc(doc(db, "users", user.uid));
+      if (snap.exists() && snap.data().docId) {
+        el.docUrlInput?.setAttribute("data-has-doc", "true");
+      }
+    } else {
+      updateStatus("Not signed in");
+      if (topLoginBtn) topLoginBtn.classList.remove("hidden");
+      if (topSignOutBtn) topSignOutBtn.classList.add("hidden");
+    }
+  });
+
+  topLoginBtn?.addEventListener("click", () => ensureLogin());
+  topSignOutBtn?.addEventListener("click", () => signOut(auth));
+
+  // Save Doc URL (extract ID and store in /users/{uid})
+  el.saveBtn?.addEventListener("click", async () => {
+    const user = await ensureLogin();
+    const url = (el.docUrlInput?.value || "").trim();
+    const m = url.match(/\/document\/d\/([a-zA-Z0-9-_]+)/);
+    if (!m) return alert("That doesn’t look like a Google Doc URL.");
+    const docId = m[1];
+    await setDoc(doc(db, "users", user.uid), { docId }, { merge: true });
+    alert("Saved! Share your Doc with the Firebase service account (Editor) so the app can write to it.");
+  });
+
+  // Send to Google Doc
+  el.sendBtn?.addEventListener("click", async () => {
+    const user = await ensureLogin();
+    const content = (el.workInput?.value || "").trim();
+    if (!content) return alert("Write something first 😊");
+    updateStatus("Sending...");
+    try {
+      await callTransfer({ content });
+      updateStatus("Sent! Check your Google Doc.");
+    } catch (e) {
+      console.error(e);
+      updateStatus("Error sending. Is your Doc shared with the service account?");
+      alert("Error sending. Make sure your Doc is shared with the service account (Editor).");
+    }
+  });
+})();

--- a/week1.html
+++ b/week1.html
@@ -354,6 +354,20 @@
         </div>
         <ul id="pfFiles" class="list-disc list-inside text-sm text-slate-700"></ul>
       </div>
+
+      <!-- Minimal Google Doc controls (keeps layout intact) -->
+      <section class="activity-card mt-6" aria-labelledby="gc-doc-title">
+        <h3 id="gc-doc-title" class="text-xl font-extrabold mb-2">Google Doc — Save &amp; Send</h3>
+        <div class="grid gap-2 md:grid-cols-[1fr_auto] items-start mb-2">
+          <input id="gcDocUrl" class="rounded-lg border border-slate-300 p-2" placeholder="Paste your Google Doc URL (Classroom copy)" />
+          <button id="gcSaveDocBtn" class="px-3 py-2 rounded-lg border border-slate-300 text-sm">Save Doc</button>
+        </div>
+        <textarea id="gcWorkInput" rows="6" class="w-full rounded-lg border border-slate-300 p-3" placeholder="Write or paste what you want to send..."></textarea>
+        <div class="mt-2">
+          <button id="gcSendBtn" class="px-3 py-2 rounded-lg bg-brand-600 text-white font-semibold hover:opacity-90">Send to Google Doc</button>
+        </div>
+        <p class="text-xs text-slate-500 mt-2">First time? Share your Doc with your teacher’s app service account (Editor) so it can write.</p>
+      </section>
     </section>
 
     <!-- Activity 1: Whiteboard “Big Paper” (same-origin embed) -->
@@ -1575,6 +1589,19 @@ onAuthStateChanged(auth, async (user) => {
 
   // if you add more units later, you can read unitSel.value and swap UNIT dynamically.
 </script>
+
+  <!-- Firebase config for Google Doc helper (replace with real keys in deployment) -->
+  <script>
+    window.__firebase_config_json = JSON.stringify({
+      apiKey: "YOUR_API_KEY",
+      authDomain: "YOUR_PROJECT.firebaseapp.com",
+      projectId: "YOUR_PROJECT",
+      appId: "YOUR_APP_ID"
+    });
+  </script>
+
+  <!-- Minimal Google Doc controls logic -->
+  <script type="module" src="./js/app-docs.js"></script>
 
 
 </body>


### PR DESCRIPTION
## Summary
- add a Firebase Functions package with a callable `transferToDoc` helper that appends portfolio submissions into each student’s saved Google Doc
- add a lightweight browser module (`js/app-docs.js`) to save Doc URLs, reuse existing Google auth buttons, and call the callable function
- expose Doc URL + send controls in the Week 1 portfolio card and load the new client script/config without disturbing existing layout

## Testing
- not run (static HTML project)


------
https://chatgpt.com/codex/tasks/task_b_68d5b8ad4a0883278336ab326066592d